### PR TITLE
Add project quick links, fix chibi back-navigation, and wrap project …

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -269,9 +269,11 @@ function AboutContent() {
             training data to the deployed model. That curiosity is what drives me.
           </p>
           <p>
-            When I&apos;m not building, you&apos;ll find me exploring new technologies,
-            tinkering with hardware, or helping others learn to code. I&apos;m always
-            looking for the next challenge that pushes me somewhere new.
+            Away from the keyboard, I like to stay moving. You&apos;ll usually find
+            me rock climbing and hiking, playing pickup basketball, swimming, or
+            at the gym. When I&apos;m winding down, I&apos;m either listening to or
+            creating music, exploring new food spots, watching movies, or
+            building legos.
           </p>
         </div>
       </ScrollReveal>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -326,14 +326,9 @@ export default function Home() {
           </div>
 
           {/* Right column — Chibi avatar centered */}
-          <motion.div
-            initial={{ opacity: 0, scale: 0.8 }}
-            animate={{ opacity: 1, scale: 1 }}
-            transition={{ duration: 0.8, delay: 1.6, ease: [0.23, 1, 0.32, 1] }}
-            className="hidden md:flex items-center justify-end"
-          >
+          <div className="hidden md:flex items-center justify-end">
             <ChibiAvatar className="w-[104%] lg:w-[110%] xl:w-[117%] max-w-[650px]" />
-          </motion.div>
+          </div>
         </div>
 
         {/* Centered scroll-down arrow */}

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,5 +1,7 @@
 import { notFound } from "next/navigation";
 import { getProjectBySlug, getAllProjects } from "@/lib/projects";
+import ProjectLayout from "@/components/project-layout";
+
 const componentMap: Record<string, React.ComponentType> = {
 };
 
@@ -19,15 +21,15 @@ export default async function ProjectPage({ params }: Props) {
 
   const Component = componentMap[slug];
 
-  if (!Component) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <p className="text-fg-muted text-sm tracking-wider">
-          Project page coming soon.
+  return (
+    <ProjectLayout project={project}>
+      {Component ? (
+        <Component />
+      ) : (
+        <p className="text-fg-muted text-sm tracking-wider py-12">
+          Project description coming soon.
         </p>
-      </div>
-    );
-  }
-
-  return <Component />;
+      )}
+    </ProjectLayout>
+  );
 }

--- a/src/components/chibi-avatar.tsx
+++ b/src/components/chibi-avatar.tsx
@@ -9,6 +9,10 @@ const SKIN_SHADOW = "#a47850";
 const HAIR = "#1a1410"; // Black hair
 const GLASSES = "#1a1a2e"; // Black glasses
 
+// Track whether the entrance animation has already played this session.
+// On client-side navigation back, we skip the entrance and show immediately.
+let hasPlayedEntrance = false;
+
 export default function ChibiAvatar({ className = "" }: { className?: string }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const svgRef = useRef<SVGSVGElement>(null);
@@ -232,53 +236,66 @@ export default function ChibiAvatar({ className = "" }: { className?: string }) 
       }
     };
 
-    // Main entrance timeline
-    const meTl = gsap.timeline({
-      onComplete: addMouseEvent,
-      delay: 1,
-    });
+    // Main entrance timeline — skip animation on client-side re-navigation
+    let meTl: gsap.core.Timeline;
 
-    meTl
-      .from(svg.querySelector(".me"), {
-        duration: 1,
-        yPercent: 100,
-        ease: "elastic.out(0.5, 0.4)",
-      }, 0.5)
-      .from(svg.querySelectorAll(".head, .hair-back, .shadow"), {
-        duration: 0.9,
-        yPercent: 20,
-        ease: "elastic.out(0.58, 0.25)",
-      }, 0.6)
-      .from(svg.querySelector(".ear-right"), {
-        duration: 1,
-        rotate: 40,
-        yPercent: 10,
-        ease: "elastic.out(0.5, 0.2)",
-      }, 0.7)
-      .from(svg.querySelector(".ear-left"), {
-        duration: 1,
-        rotate: -40,
-        yPercent: 10,
-        ease: "elastic.out(0.5, 0.2)",
-      }, 0.7)
-      .to(svg.querySelector(".glasses"), {
-        duration: 1,
-        keyframes: [{ yPercent: -10 }, { yPercent: 0 }],
-        ease: "elastic.out(0.5, 0.2)",
-      }, 0.75)
-      .from(svg.querySelectorAll(".eyebrow-right, .eyebrow-left"), {
-        duration: 1,
-        yPercent: 300,
-        ease: "elastic.out(0.5, 0.2)",
-      }, 0.7)
-      .to(svg.querySelectorAll(".eye-right, .eye-left"), {
-        duration: 0.01,
-        opacity: 1,
-      }, 0.85)
-      .to(svg.querySelectorAll(".eye-right-2, .eye-left-2"), {
-        duration: 0.01,
-        opacity: 0,
-      }, 0.85);
+    if (hasPlayedEntrance) {
+      // Already played once this session — show immediately and wire up events
+      gsap.set(svg.querySelector(".me"), { opacity: 1 });
+      gsap.set(svg.querySelectorAll(".eye-right, .eye-left"), { opacity: 1 });
+      gsap.set(svg.querySelectorAll(".eye-right-2, .eye-left-2"), { opacity: 0 });
+      meTl = gsap.timeline({ onComplete: addMouseEvent });
+      // Tiny no-op tween so the timeline fires onComplete
+      meTl.to({}, { duration: 0.01 });
+    } else {
+      hasPlayedEntrance = true;
+      meTl = gsap.timeline({
+        onComplete: addMouseEvent,
+        delay: 1,
+      });
+
+      meTl
+        .from(svg.querySelector(".me"), {
+          duration: 1,
+          yPercent: 100,
+          ease: "elastic.out(0.5, 0.4)",
+        }, 0.5)
+        .from(svg.querySelectorAll(".head, .hair-back, .shadow"), {
+          duration: 0.9,
+          yPercent: 20,
+          ease: "elastic.out(0.58, 0.25)",
+        }, 0.6)
+        .from(svg.querySelector(".ear-right"), {
+          duration: 1,
+          rotate: 40,
+          yPercent: 10,
+          ease: "elastic.out(0.5, 0.2)",
+        }, 0.7)
+        .from(svg.querySelector(".ear-left"), {
+          duration: 1,
+          rotate: -40,
+          yPercent: 10,
+          ease: "elastic.out(0.5, 0.2)",
+        }, 0.7)
+        .to(svg.querySelector(".glasses"), {
+          duration: 1,
+          keyframes: [{ yPercent: -10 }, { yPercent: 0 }],
+          ease: "elastic.out(0.5, 0.2)",
+        }, 0.75)
+        .from(svg.querySelectorAll(".eyebrow-right, .eyebrow-left"), {
+          duration: 1,
+          yPercent: 300,
+          ease: "elastic.out(0.5, 0.2)",
+        }, 0.7)
+        .to(svg.querySelectorAll(".eye-right, .eye-left"), {
+          duration: 0.01,
+          opacity: 1,
+        }, 0.85)
+        .to(svg.querySelectorAll(".eye-right-2, .eye-left-2"), {
+          duration: 0.01,
+          opacity: 0,
+        }, 0.85);
+    }
 
     // Blob gradient color cycle — slow ~8s loop through blue/purple palette
     const blobGradient = gsap.timeline({ repeat: -1, yoyo: true });
@@ -397,7 +414,7 @@ export default function ChibiAvatar({ className = "" }: { className?: string }) 
             </g>
 
             {/* Neck shadow */}
-            <path className="shadow" d="M95.82 122.36h18.41v14.31s-10.5 5.54-18.41 0z" fill={SKIN_SHADOW} />
+            <path className="neck-shadow" d="M95.82 122.36h18.41v14.31s-10.5 5.54-18.41 0z" fill={SKIN_SHADOW} />
 
             <g className="head">
               {/* Left ear */}

--- a/src/components/project-card.tsx
+++ b/src/components/project-card.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { motion, useInView } from "framer-motion";
 import { useRef } from "react";
-import type { ProjectMeta } from "@/lib/projects";
+import type { ProjectMeta, ProjectLink } from "@/lib/projects";
 
 interface ProjectCardProps {
   project: ProjectMeta;
@@ -16,6 +16,40 @@ const categoryLabels: Record<string, string> = {
   embedded: "Robotics",
   software: "Software",
 };
+
+function LinkIcon({ type }: { type: ProjectLink["type"] }) {
+  switch (type) {
+    case "github":
+      return (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
+        </svg>
+      );
+    case "website":
+      return (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="12" cy="12" r="10" />
+          <path d="M2 12h20M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z" />
+        </svg>
+      );
+    case "devpost":
+      return (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M6.002 1.61L0 12.004 6.002 22.39h11.996L24 12.004 17.998 1.61zm1.593 4.084h3.947c3.605 0 6.276 1.695 6.276 6.31 0 4.436-3.21 6.302-6.456 6.302H7.595zm2.517 2.449v7.714h1.241c2.646 0 3.862-1.55 3.862-3.861.009-2.569-1.096-3.853-3.767-3.853z" />
+        </svg>
+      );
+    case "documentation":
+      return (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+          <polyline points="14 2 14 8 20 8" />
+          <line x1="16" y1="13" x2="8" y2="13" />
+          <line x1="16" y1="17" x2="8" y2="17" />
+          <polyline points="10 9 9 9 8 9" />
+        </svg>
+      );
+  }
+}
 
 export default function ProjectCard({ project, index }: ProjectCardProps) {
   const ref = useRef(null);
@@ -33,80 +67,94 @@ export default function ProjectCard({ project, index }: ProjectCardProps) {
         ease: [0.23, 1, 0.32, 1],
       }}
     >
-      <Link href={`/projects/${project.slug}`} className="group block">
-        <article
-          className="border border-divider bg-white transition-all will-change-transform"
-          style={{
-            boxShadow: "0 4px 24px rgba(26,26,46,0.06), 0 1px 4px rgba(26,26,46,0.03)",
-            transitionTimingFunction: "cubic-bezier(0.23, 1, 0.32, 1)",
-            transitionDuration: "400ms",
-          }}
-          onMouseEnter={(e) => {
-            const el = e.currentTarget;
-            el.style.transform = "perspective(1200px) rotateX(2deg) rotateY(-3deg) translateY(-8px) scale(1.01)";
-            el.style.boxShadow = "0 20px 50px rgba(26,26,46,0.12), 0 0 20px rgba(74,108,247,0.08)";
-            el.style.borderColor = "rgba(74,108,247,0.15)";
-          }}
-          onMouseLeave={(e) => {
-            const el = e.currentTarget;
-            el.style.transform = "";
-            el.style.boxShadow = "0 4px 24px rgba(26,26,46,0.06), 0 1px 4px rgba(26,26,46,0.03)";
-            el.style.borderColor = "";
-          }}
-        >
-          {/* Thumbnail — rounded independently so 3D transform doesn't break clip */}
-          <div className="relative overflow-hidden aspect-[4/3] bg-bg-secondary">
-            {project.thumbnail && /\.(mp4|webm|mov)$/i.test(project.thumbnail) ? (
-              <video
-                src={project.thumbnail}
-                autoPlay
-                loop
-                muted
-                playsInline
-                className="absolute inset-0 w-full h-full object-contain transition-transform duration-700 ease-out group-hover:scale-[1.03]"
-              />
-            ) : project.thumbnail ? (
-              <Image
-                src={project.thumbnail}
-                alt={project.title}
-                fill
-                unoptimized={project.thumbnail.endsWith(".gif")}
-                className="object-cover transition-transform duration-700 ease-out group-hover:scale-[1.03]"
-                sizes="(max-width: 768px) 100vw, 33vw"
-              />
-            ) : (
-              <div className="absolute inset-0 flex items-center justify-center bg-bg-secondary">
-                <span className="font-[family-name:var(--font-display)] text-lg font-bold text-fg-muted/20 uppercase tracking-widest">
-                  {project.category}
+      <article
+        className="group relative border border-divider bg-white transition-all will-change-transform"
+        style={{
+          boxShadow: "0 4px 24px rgba(26,26,46,0.06), 0 1px 4px rgba(26,26,46,0.03)",
+          transitionTimingFunction: "cubic-bezier(0.23, 1, 0.32, 1)",
+          transitionDuration: "400ms",
+        }}
+        onMouseEnter={(e) => {
+          const el = e.currentTarget;
+          el.style.transform = "perspective(1200px) rotateX(2deg) rotateY(-3deg) translateY(-8px) scale(1.01)";
+          el.style.boxShadow = "0 20px 50px rgba(26,26,46,0.12), 0 0 20px rgba(74,108,247,0.08)";
+          el.style.borderColor = "rgba(74,108,247,0.15)";
+        }}
+        onMouseLeave={(e) => {
+          const el = e.currentTarget;
+          el.style.transform = "";
+          el.style.boxShadow = "0 4px 24px rgba(26,26,46,0.06), 0 1px 4px rgba(26,26,46,0.03)";
+          el.style.borderColor = "";
+        }}
+      >
+        {/* Stretched link — covers entire card for project page navigation */}
+        <Link href={`/projects/${project.slug}`} className="absolute inset-0 z-0" aria-label={project.title} />
+
+        {/* Thumbnail */}
+        <div className="relative overflow-hidden aspect-[4/3] bg-bg-secondary">
+          {project.thumbnail && /\.(mp4|webm|mov)$/i.test(project.thumbnail) ? (
+            <video
+              src={project.thumbnail}
+              autoPlay
+              loop
+              muted
+              playsInline
+              className="absolute inset-0 w-full h-full object-contain transition-transform duration-700 ease-out group-hover:scale-[1.03]"
+            />
+          ) : project.thumbnail ? (
+            <Image
+              src={project.thumbnail}
+              alt={project.title}
+              fill
+              unoptimized={project.thumbnail.endsWith(".gif")}
+              className="object-cover transition-transform duration-700 ease-out group-hover:scale-[1.03]"
+              sizes="(max-width: 768px) 100vw, 33vw"
+            />
+          ) : (
+            <div className="absolute inset-0 flex items-center justify-center bg-bg-secondary">
+              <span className="font-[family-name:var(--font-display)] text-lg font-bold text-fg-muted/20 uppercase tracking-widest">
+                {project.category}
+              </span>
+            </div>
+          )}
+        </div>
+
+        {/* Content */}
+        <div className="relative p-5 md:p-6">
+          <span className="inline-block px-3 py-1 rounded-full text-[10px] tracking-widest uppercase font-semibold mb-3 bg-accent-blue/[0.07] text-accent-blue">
+            {categoryLabels[project.category] || project.category}
+          </span>
+
+          <h3 className="font-[family-name:var(--font-display)] text-lg lg:text-xl font-bold text-fg-primary mb-2 group-hover:text-accent-blue transition-colors duration-300">
+            {project.title}
+          </h3>
+
+          <p className="text-sm leading-relaxed text-fg-muted line-clamp-2 mb-4">
+            {project.description}
+          </p>
+
+          <div className="flex items-center justify-between">
+            <div className="flex flex-wrap gap-x-3 gap-y-1">
+              {project.tags.slice(0, 4).map((tag) => (
+                <span key={tag} className="text-[11px] text-fg-muted/50 font-medium">
+                  {tag}
                 </span>
-              </div>
-            )}
+              ))}
+            </div>
 
-          </div>
-
-          {/* Content */}
-          <div className="p-5 md:p-6">
-            <span className="inline-block px-3 py-1 rounded-full text-[10px] tracking-widest uppercase font-semibold mb-3 bg-accent-blue/[0.07] text-accent-blue">
-              {categoryLabels[project.category] || project.category}
-            </span>
-
-            <h3 className="font-[family-name:var(--font-display)] text-lg lg:text-xl font-bold text-fg-primary mb-2 group-hover:text-accent-blue transition-colors duration-300">
-              {project.title}
-            </h3>
-
-            <p className="text-sm leading-relaxed text-fg-muted line-clamp-2 mb-4">
-              {project.description}
-            </p>
-
-            <div className="flex items-center justify-between">
-              <div className="flex flex-wrap gap-x-3 gap-y-1">
-                {project.tags.slice(0, 4).map((tag) => (
-                  <span key={tag} className="text-[11px] text-fg-muted/50 font-medium">
-                    {tag}
-                  </span>
-                ))}
-              </div>
-
+            <div className="relative z-10 flex items-center gap-2 flex-shrink-0">
+              {project.links?.map((link) => (
+                <a
+                  key={link.href}
+                  href={link.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={link.label}
+                  className="w-7 h-7 rounded-full border border-divider flex items-center justify-center text-fg-muted/50 hover:text-accent-blue hover:border-accent-blue/30 transition-colors duration-200"
+                >
+                  <LinkIcon type={link.type} />
+                </a>
+              ))}
               <svg
                 width="18"
                 height="18"
@@ -116,14 +164,14 @@ export default function ProjectCard({ project, index }: ProjectCardProps) {
                 strokeWidth="2"
                 strokeLinecap="round"
                 strokeLinejoin="round"
-                className="text-fg-muted/30 group-hover:text-accent-blue group-hover:translate-x-1 transition-all duration-300 flex-shrink-0"
+                className="text-fg-muted/30 group-hover:text-accent-blue group-hover:translate-x-1 transition-all duration-300 ml-1"
               >
                 <path d="M5 12h14M12 5l7 7-7 7" />
               </svg>
             </div>
           </div>
-        </article>
-      </Link>
+        </div>
+      </article>
     </motion.div>
   );
 }

--- a/src/components/project-layout.tsx
+++ b/src/components/project-layout.tsx
@@ -3,11 +3,45 @@
 import { motion } from "framer-motion";
 import Nav from "@/components/nav";
 import SocialLinks from "@/components/social-links";
-import type { ProjectMeta } from "@/lib/projects";
+import type { ProjectMeta, ProjectLink } from "@/lib/projects";
 
 interface ProjectLayoutProps {
   project: ProjectMeta;
   children: React.ReactNode;
+}
+
+function LinkIcon({ type }: { type: ProjectLink["type"] }) {
+  switch (type) {
+    case "github":
+      return (
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
+        </svg>
+      );
+    case "website":
+      return (
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="12" cy="12" r="10" />
+          <path d="M2 12h20M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z" />
+        </svg>
+      );
+    case "devpost":
+      return (
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M6.002 1.61L0 12.004 6.002 22.39h11.996L24 12.004 17.998 1.61zm1.593 4.084h3.947c3.605 0 6.276 1.695 6.276 6.31 0 4.436-3.21 6.302-6.456 6.302H7.595zm2.517 2.449v7.714h1.241c2.646 0 3.862-1.55 3.862-3.861.009-2.569-1.096-3.853-3.767-3.853z" />
+        </svg>
+      );
+    case "documentation":
+      return (
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+          <polyline points="14 2 14 8 20 8" />
+          <line x1="16" y1="13" x2="8" y2="13" />
+          <line x1="16" y1="17" x2="8" y2="17" />
+          <polyline points="10 9 9 9 8 9" />
+        </svg>
+      );
+  }
 }
 
 export default function ProjectLayout({ project, children }: ProjectLayoutProps) {
@@ -69,6 +103,29 @@ export default function ProjectLayout({ project, children }: ProjectLayoutProps)
             </span>
           ))}
         </motion.div>
+
+        {/* Quick links */}
+        {project.links && project.links.length > 0 && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.5, delay: 0.6 }}
+            className="flex flex-wrap items-center gap-3 mt-6"
+          >
+            {project.links.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 px-3.5 py-2 rounded-full border border-divider text-fg-muted text-xs font-medium tracking-wide hover:text-accent-blue hover:border-accent-blue/30 transition-colors duration-200"
+              >
+                <LinkIcon type={link.type} />
+                {link.label}
+              </a>
+            ))}
+          </motion.div>
+        )}
 
         {/* Dimension line divider */}
         <div className="dimension-line mt-12" />

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -1,3 +1,9 @@
+export interface ProjectLink {
+  label: string;
+  href: string;
+  type: "github" | "website" | "devpost" | "documentation";
+}
+
 export interface ProjectMeta {
   slug: string;
   title: string;
@@ -6,6 +12,7 @@ export interface ProjectMeta {
   thumbnail: string;
   year: string;
   category: "software" | "embedded" | "ml";
+  links?: ProjectLink[];
 }
 
 export const projects: ProjectMeta[] = [
@@ -18,6 +25,21 @@ export const projects: ProjectMeta[] = [
     thumbnail: "/img/smartepants_cover.JPG",
     year: "2025",
     category: "embedded",
+    links: [
+      { label: "Website", href: "https://www.macexo.com/", type: "website" },
+      { label: "GitHub", href: "https://github.com/McMaster-Exoskeleton", type: "github" },
+    ],
+  },
+  {
+    slug: "snoopi",
+    title: "SNOOPI",
+    description:
+      "Robotics software for the Unitree Go 2 robot in hospital settings. Built a task management and health monitoring interface, implemented intelligent models with Python and OpenCV, and used ROS2 for sensor data visualization.",
+    tags: ["Python", "OpenCV", "ROS2", "Unitree Go 2"],
+    thumbnail: "/video/snoopi_cover.mp4",
+    year: "2025",
+    category: "embedded",
+    links: [],
   },
   {
     slug: "chessmate",
@@ -28,6 +50,10 @@ export const projects: ProjectMeta[] = [
     thumbnail: "/video/chessmate_cover.mp4",
     year: "2025",
     category: "embedded",
+    links: [
+      { label: "Devpost", href: "https://devpost.com/software/chessmate-nwygvq", type: "devpost" },
+      { label: "GitHub", href: "https://github.com/o-bm/ChessMate", type: "github" },
+    ],
   },
   {
     slug: "carlos-portfolio",
@@ -38,6 +64,10 @@ export const projects: ProjectMeta[] = [
     thumbnail: "/video/carlosPortfolio_cover.mp4",
     year: "2024",
     category: "software",
+    links: [
+      { label: "Website", href: "https://photography-portfolio-two-omega.vercel.app/", type: "website" },
+      { label: "GitHub", href: "https://github.com/JuanR-Git/photography-portfolio", type: "github" },
+    ],
   },
   {
     slug: "trace-ai",
@@ -48,6 +78,10 @@ export const projects: ProjectMeta[] = [
     thumbnail: "/video/traceai_cover.mp4",
     year: "2025",
     category: "software",
+    links: [
+      { label: "Devpost", href: "https://devpost.com/software/traceai", type: "devpost" },
+      { label: "GitHub", href: "https://github.com/umarkhan135/TraceAI", type: "github" },
+    ],
   },
   {
     slug: "paced",
@@ -58,6 +92,9 @@ export const projects: ProjectMeta[] = [
     thumbnail: "/img/paced_cover.png",
     year: "2024",
     category: "embedded",
+    links: [
+      { label: "Documentation", href: "https://drive.google.com/file/d/1ZIhKlqEDUXXbrAUTR-R1dYmR0VYDw45Z/view", type: "documentation" },
+    ],
   },
   {
     slug: "blinking-id",
@@ -68,6 +105,7 @@ export const projects: ProjectMeta[] = [
     thumbnail: "/video/blinkid_cover.mp4",
     year: "2024",
     category: "embedded",
+    links: [],
   },
   {
     slug: "recycle-bot",
@@ -78,6 +116,9 @@ export const projects: ProjectMeta[] = [
     thumbnail: "/video/recycleBot_cover.mp4",
     year: "2023",
     category: "embedded",
+    links: [
+      { label: "GitHub", href: "https://github.com/JuanR-Git/Recycle-Bot", type: "github" },
+    ],
   },
   {
     slug: "juan-reyes-v1",
@@ -88,6 +129,10 @@ export const projects: ProjectMeta[] = [
     thumbnail: "/video/juanreyesv1_cover.mp4",
     year: "2022",
     category: "software",
+    links: [
+      { label: "Website", href: "https://juan-reyes-portfolio.vercel.app/", type: "website" },
+      { label: "GitHub", href: "https://github.com/JuanR-Git/juan-reyes", type: "github" },
+    ],
   },
   {
     slug: "wary",
@@ -98,6 +143,10 @@ export const projects: ProjectMeta[] = [
     thumbnail: "/video/wary_cover.mp4",
     year: "2022",
     category: "software",
+    links: [
+      { label: "Devpost", href: "https://devpost.com/software/wary", type: "devpost" },
+      { label: "GitHub", href: "https://github.com/JuanR-Git/Wary", type: "github" },
+    ],
   },
   {
     slug: "nba-injury-predictor",
@@ -108,6 +157,9 @@ export const projects: ProjectMeta[] = [
     thumbnail: "https://images.unsplash.com/photo-1546519638-68e109498ffc?w=1200&q=85&auto=format&fit=crop",
     year: "2025",
     category: "ml",
+    links: [
+      { label: "GitHub", href: "https://github.com/JuanR-Git/nba-injury-predictor", type: "github" },
+    ],
   },
   {
     slug: "credit-classifier",
@@ -118,6 +170,9 @@ export const projects: ProjectMeta[] = [
     thumbnail: "/img/creditcardclass_cover.png",
     year: "2024",
     category: "ml",
+    links: [
+      { label: "Documentation", href: "https://drive.google.com/file/d/15uYLo_wlJvyOqTWl3uPpSPNr0vupmjIV/view?usp=sharing", type: "documentation" },
+    ],
   },
 ];
 


### PR DESCRIPTION
…pages in layout

- Add quick links (GitHub, Website, Devpost, Documentation) to all project cards using a stretched-link pattern to avoid nested <a> hydration errors
- Show links on project detail pages alongside "coming soon" message
- Fix chibi avatar not appearing on client-side back-navigation by removing Framer Motion wrapper and skipping GSAP entrance delay on re-mounts
- Wrap all project pages in ProjectLayout for consistent header/tags/links